### PR TITLE
select for update improvement

### DIFF
--- a/sql_server/pyodbc/operations.py
+++ b/sql_server/pyodbc/operations.py
@@ -234,11 +234,11 @@ class DatabaseOperations(BaseDatabaseOperations):
         Returns the FOR UPDATE SQL clause to lock rows for an update operation.
         """
         if skip_locked:
-            return 'WITH (NOLOCK)'
+            return 'WITH (ROWLOCK, UPDLOCK, READPAST, FORCESEEK)'
         elif nowait:
-            return 'WITH (NOWAIT, ROWLOCK, UPDLOCK)'
+            return 'WITH (NOWAIT, ROWLOCK, UPDLOCK, FORCESEEK)'
         else:
-            return 'WITH (ROWLOCK, UPDLOCK)'
+            return 'WITH (ROWLOCK, UPDLOCK, FORCESEEK)'
 
     def format_for_duration_arithmetic(self, sql):
         if sql == '%s':


### PR DESCRIPTION
(Solution found by François Guilbeault)
We have in our project a few select_for_update() that were blocking each other even though the rows were mutually exclusive.

After a bit of investigation, we found out that the query optimizer will scan the table instead of seeking it by index for small tables. By scanning it, it will lock all the row it scans even if they are not part of the `SELECT` statement.
The way to avoid that is to add `FORCESEEK` within the `WITH` hint. It has no drawback, but can help concurrent select_for_update with mutually exclusive rows that don't block themself.

Also, after investigation, I think the expected `skip_locked` behavior needs `READPAST` instead of `NOLOCK`.